### PR TITLE
fix: Handle RecipeDefs

### DIFF
--- a/1.5/Patches/DubSkylightsGlassPatch.xml
+++ b/1.5/Patches/DubSkylightsGlassPatch.xml
@@ -12,6 +12,16 @@
 				<xpath>Defs/ThingDef/costList/GlassPane</xpath>
 				<name>Glass</name>
 			</li>
+			<li Class="PatchOperationSetName">
+				<success>Always</success>
+				<xpath>Defs/RecipeDef/ingredients/GlassPane</xpath>
+				<name>Glass</name>
+			</li>
+			<li Class="PatchOperationSetName">
+				<success>Always</success>
+				<xpath>Defs/RecipeDef/products/GlassPane</xpath>
+				<name>Glass</name>
+			</li>
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/RecipeDef[defName = "SmeltGlass"]</xpath>
 			</li>


### PR DESCRIPTION
From what I can tell, this should cover Biomes Caverns along with any other cases that use Glass Panes in RecipeDefs. Technically only `products` is needed to resolve #1, but I included `ingredients` in case other mods might run into a similar problem.

Feel free to edit/close if you see a better solution.

Fixes #1 